### PR TITLE
add some comments for exercise 4 and 5 to make clear they cannot run in parallel

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,4 @@
 This is the top level project for the Scala ITR. It will contain all the exercises and the test suite.
+
+Tests can be run from /labs folder with command:
+    sbt 'testOnly org.scalalabs.basic.lab01.HelloWorldExerciseTest'

--- a/README
+++ b/README
@@ -1,4 +1,5 @@
 This is the top level project for the Scala ITR. It will contain all the exercises and the test suite.
 
-Tests can be run from /labs folder with command:
+**How to run test**
+Tests can be run from within labs directory like this:
     sbt 'testOnly org.scalalabs.basic.lab01.HelloWorldExerciseTest'

--- a/README
+++ b/README
@@ -1,5 +1,0 @@
-This is the top level project for the Scala ITR. It will contain all the exercises and the test suite.
-
-**How to run test**
-Tests can be run from within labs directory like this:
-    sbt 'testOnly org.scalalabs.basic.lab01.HelloWorldExerciseTest'

--- a/labs/src/main/scala/org/scalalabs/basic/lab01/OOExercise.scala
+++ b/labs/src/main/scala/org/scalalabs/basic/lab01/OOExercise.scala
@@ -39,6 +39,10 @@ import scala.language.implicitConversions
  * - Extend the conversion method from Dollar to Euro with an implicit parameter
  *   of type [[org.scalalabs.basic.lab01.CurrencyConverter]]
  * - Use the implicit CurrencyConverter to do the conversion.
+ *
+ * Note:
+ * For Exercise 4 and 5 you will need different versions of the conversion method.
+ * It's okay if you can pass only either 4 or 5 at a time.
  */
 class Euro {
 

--- a/solutions/src/main/scala/org/scalalabs/basic/lab01/OOExercise.scala
+++ b/solutions/src/main/scala/org/scalalabs/basic/lab01/OOExercise.scala
@@ -27,10 +27,7 @@ object Euro {
   implicit class EuroInt(val i: Int) extends AnyVal {
     def *(euro: Euro) = euro * i
   }
-
-  //implicit def fromDollar(dollar: Dollar): Euro = Euro.fromCents((DefaultCurrencyConverter.toEuroCents(dollar.inCents)).toInt)
-
-  implicit def fromDollar(dollar: Dollar)(implicit converter: CurrencyConverter): Euro = Euro.fromCents(converter.toEuroCents(dollar.inCents))
+  implicit def fromDollar(dollar: Dollar)(implicit converter: CurrencyConverter = DefaultCurrencyConverter): Euro = Euro.fromCents(converter.toEuroCents(dollar.inCents))
 }
 
 class Dollar(val dollar: Int, val cents: Int = 0) extends Currency("USD") {

--- a/solutions/src/main/scala/org/scalalabs/basic/lab01/OOExercise.scala
+++ b/solutions/src/main/scala/org/scalalabs/basic/lab01/OOExercise.scala
@@ -27,6 +27,13 @@ object Euro {
   implicit class EuroInt(val i: Int) extends AnyVal {
     def *(euro: Euro) = euro * i
   }
+  // solution for exercise 4
+  // implicit def fromDollar(dollar: Dollar): Euro = Euro.fromCents((DefaultCurrencyConverter.toEuroCents(dollar.inCents)).toInt)
+
+  // solution for exercise 5
+  // implicit def fromDollar(dollar: Dollar)(implicit converter: CurrencyConverter): Euro = Euro.fromCents(converter.toEuroCents(dollar.inCents))
+
+  //unified version to run both 4 and 5
   implicit def fromDollar(dollar: Dollar)(implicit converter: CurrencyConverter = DefaultCurrencyConverter): Euro = Euro.fromCents(converter.toEuroCents(dollar.inCents))
 }
 

--- a/solutions/src/main/scala/org/scalalabs/basic/lab01/OOExercise.scala
+++ b/solutions/src/main/scala/org/scalalabs/basic/lab01/OOExercise.scala
@@ -31,10 +31,7 @@ object Euro {
   // implicit def fromDollar(dollar: Dollar): Euro = Euro.fromCents((DefaultCurrencyConverter.toEuroCents(dollar.inCents)).toInt)
 
   // solution for exercise 5
-  // implicit def fromDollar(dollar: Dollar)(implicit converter: CurrencyConverter): Euro = Euro.fromCents(converter.toEuroCents(dollar.inCents))
-
-  //unified version to run both 4 and 5
-  implicit def fromDollar(dollar: Dollar)(implicit converter: CurrencyConverter = DefaultCurrencyConverter): Euro = Euro.fromCents(converter.toEuroCents(dollar.inCents))
+  implicit def fromDollar(dollar: Dollar)(implicit converter: CurrencyConverter): Euro = Euro.fromCents(converter.toEuroCents(dollar.inCents))
 }
 
 class Dollar(val dollar: Int, val cents: Int = 0) extends Currency("USD") {


### PR DESCRIPTION
the current provided solution for 00ExerciseTest requires to uncomment one of the 2 provided solutions; it was not possible to run the complete test with just 1 version of the "fromDollar" method.

This PR is a small fix in that it adds the defaultConverter in the implicit parameter as default.
With this all test cases of 00ExerciseTest work without the need to uncomment the one or other solution.
